### PR TITLE
add support for using unencrypted backend keys

### DIFF
--- a/bend/.gitignore
+++ b/bend/.gitignore
@@ -1,2 +1,3 @@
 credentials.json*
 *_rsa*
+cr.json


### PR DESCRIPTION
- call node with environment variable `useUnEnc=true`
    - *NB* no space after =
- or if platform_arch does not match 'linux_x86-64'
- sops will be used as usual if env var not provided
